### PR TITLE
StunChance_Event_Need_Test

### DIFF
--- a/Program/loc_ai/LAi_fightparams.c
+++ b/Program/loc_ai/LAi_fightparams.c
@@ -1747,6 +1747,7 @@ float LAi_NPC_StunChance()
 	if (IsCharacterPerkOn(chr, "SwordplayProfessional")) return npc_return_tmp -= 50;	
 	if (IsCharacterPerkOn(chr, "AdvancedDefence")) return npc_return_tmp -= 30;
 	if (IsCharacterPerkOn(chr, "BasicDefence")) return npc_return_tmp -= 10;
+	return npc_return_tmp;
 }
 
 //Параметры стрельбы

--- a/Program/loc_ai/LAi_fightparams.c
+++ b/Program/loc_ai/LAi_fightparams.c
@@ -1738,6 +1738,16 @@ bool LAi_NPC_EnableRecoil()
 	return npc_return_tmpb;
 }
 
+#event_handler("NPC_Event_StunChance","LAi_NPC_StunChance");//Добавлен евент на стан после удара. Шансы расписаны ниже. Lipsar
+float LAi_NPC_StunChance()
+{
+	aref chr = GetEventData();
+	npc_return_tmp = 100;
+	if (CheckAttribute(chr,"cirassid")) npc_return_tmp -= 35;
+	if (IsCharacterPerkOn(chr, "SwordplayProfessional")) return npc_return_tmp -= 50;	
+	if (IsCharacterPerkOn(chr, "AdvancedDefence")) return npc_return_tmp -= 30;
+	if (IsCharacterPerkOn(chr, "BasicDefence")) return npc_return_tmp -= 10;
+}
 
 //Параметры стрельбы
 //Вероятность желания выстрелить - кубик с такой вероятностью кидается 2 раза в секунду


### PR DESCRIPTION
New event, that calculates chance of stun after hit, depending on char def perks, like BasicDefence, AdvancedDefence, SwordPlayProfessional and cirass availability.