### PR TITLE
Food Fix

### DIFF
--- a/Program/ITEMS/items_utilite.c
+++ b/Program/ITEMS/items_utilite.c
@@ -62,7 +62,7 @@ bool EnableFoodUsing(ref mc, aref arItm)
 void DoCharacterUsedFood(ref chref, string itmID)
 {
 	aref arItm;
-	if( Items_FindItem(itmID,&arItm)<0 || CheckAttribute(chref,"chr_ai.Swift")) return;
+	if( Items_FindItem(itmID,&arItm)<0 ) return;
 	TakeItemFromCharacter(chref,itmID);
 
 	if( CheckAttribute(arItm,"Food.energy") )

--- a/Program/ITEMS/items_utilite.c
+++ b/Program/ITEMS/items_utilite.c
@@ -62,10 +62,10 @@ bool EnableFoodUsing(ref mc, aref arItm)
 void DoCharacterUsedFood(ref chref, string itmID)
 {
 	aref arItm;
-	if(Items_FindItem(itmID,&arItm)<0) return;
+	if( Items_FindItem(itmID,&arItm)<0 || CheckAttribute(chref,"chr_ai.Swift")) return;
 	TakeItemFromCharacter(chref,itmID);
 
-	if( Items_FindItem(itmID,&arItm)<0 || CheckAttribute(chref,"chr_ai.Swift")) return;
+	if( CheckAttribute(arItm,"Food.energy") ) return;
 	{
 		chref.chr_ai.noeat = 10.0;
 		LAi_UseEnergyBottle(chref,stf(arItm.Food.energy));

--- a/Program/ITEMS/items_utilite.c
+++ b/Program/ITEMS/items_utilite.c
@@ -62,7 +62,7 @@ bool EnableFoodUsing(ref mc, aref arItm)
 void DoCharacterUsedFood(ref chref, string itmID)
 {
 	aref arItm;
-	if( Items_FindItem(itmID,&arItm)<0 ) return;
+	if(Items_FindItem(itmID,&arItm)<0 || !CanBeUseFood(chref)) return;
 	TakeItemFromCharacter(chref,itmID);
 
 	if( CheckAttribute(arItm,"Food.energy") )

--- a/Program/ITEMS/items_utilite.c
+++ b/Program/ITEMS/items_utilite.c
@@ -65,7 +65,7 @@ void DoCharacterUsedFood(ref chref, string itmID)
 	if( Items_FindItem(itmID,&arItm)<0 || CheckAttribute(chref,"chr_ai.Swift")) return;
 	TakeItemFromCharacter(chref,itmID);
 
-	if( CheckAttribute(arItm,"Food.energy") ) return;
+	if( CheckAttribute(arItm,"Food.energy") )
 	{
 		chref.chr_ai.noeat = 10.0;
 		LAi_UseEnergyBottle(chref,stf(arItm.Food.energy));

--- a/Program/ITEMS/items_utilite.c
+++ b/Program/ITEMS/items_utilite.c
@@ -65,7 +65,7 @@ void DoCharacterUsedFood(ref chref, string itmID)
 	if(Items_FindItem(itmID,&arItm)<0) return;
 	TakeItemFromCharacter(chref,itmID);
 
-	if( CheckAttribute(arItm,"Food.energy") )
+	if( Items_FindItem(itmID,&arItm)<0 || CheckAttribute(chref,"chr_ai.Swift")) return;
 	{
 		chref.chr_ai.noeat = 10.0;
 		LAi_UseEnergyBottle(chref,stf(arItm.Food.energy));

--- a/Program/ITEMS/items_utilite.c
+++ b/Program/ITEMS/items_utilite.c
@@ -62,7 +62,7 @@ bool EnableFoodUsing(ref mc, aref arItm)
 void DoCharacterUsedFood(ref chref, string itmID)
 {
 	aref arItm;
-	if(Items_FindItem(itmID,&arItm)<0 || !CanBeUseFood(chref)) return;
+	if(Items_FindItem(itmID,&arItm)<0) return;
 	TakeItemFromCharacter(chref,itmID);
 
 	if( CheckAttribute(arItm,"Food.energy") )

--- a/Program/loc_ai/LAi_character.c
+++ b/Program/loc_ai/LAi_character.c
@@ -1067,14 +1067,16 @@ void LAi_AllCharactersUpdate(float dltTime)
 
 			if(CheckAttribute(chr_ai, "noeat"))
 			{
-				chr_ai.noeat = stf(chr_ai.noeat) - dltTime;
-				pchar.query_delay = stf(pchar.query_delay) - dltTime;
-				if (stf(pchar.query_delay) <= 0.0)
+				if(CheckAttribute(pchar,"query_delay")) 
 				{
-					DeleteAttribute(pchar, "query_delay");
+					pchar.query_delay = stf(pchar.query_delay) - dltTime;
+					if (stf(pchar.query_delay) <= 0.0)
+					{
+						DeleteAttribute(pchar, "query_delay");
+					}
 				}
-
-
+				chr_ai.noeat = stf(chr_ai.noeat) - dltTime;
+				
 				if(stf(chr_ai.noeat) <= 0.0 )
 				{
 					DeleteAttribute(chr_ai, "noeat");

--- a/Program/loc_ai/types/LAi_guardian.c
+++ b/Program/loc_ai/types/LAi_guardian.c
@@ -115,7 +115,7 @@ void LAi_type_guardian_CharacterUpdate(aref chr, float dltTime)
 
 	string food = "";
 	float dfood;
-	if(LAi_GetCharacterEnergy(chr) < 25)
+	if(LAi_GetCharacterEnergy(chr) < LAi_GetCharacterMaxEnergy(chr) / 2)
 	{
 		dfood = LAi_GetCharacterMaxEnergy(chr) - LAi_GetCharacterEnergy(chr);
 		food = FindFoodForCharacter(chr, dfood);

--- a/Program/loc_ai/types/LAi_officer.c
+++ b/Program/loc_ai/types/LAi_officer.c
@@ -91,16 +91,16 @@ void LAi_type_officer_CharacterUpdate(aref chr, float dltTime)
 			}
 		}
 	}
-	// Lugger: Ебьба -->
+	// Lugger: Еда -->
 	string food = "";
 	float dfood;
-	if(LAi_GetCharacterEnergy(chr) < 25)
+	if(LAi_GetCharacterEnergy(chr) < LAi_GetCharacterMaxEnergy(chr) / 2)
 	{
 		dfood = LAi_GetCharacterMaxEnergy(chr) - LAi_GetCharacterEnergy(chr);
 		food = FindFoodForCharacter(chr, dfood);
 		DoCharacterUsedFood(&Characters[sti(chr.index)], food);
 	}
-	// <-- Lugger: Едьба
+	// <-- Lugger: Еда
 	//Дистанция до главного персонажа
 	float dist = 0.0;
 	float dhlt;

--- a/Program/loc_ai/types/LAi_patrol.c
+++ b/Program/loc_ai/types/LAi_patrol.c
@@ -104,7 +104,7 @@ void LAi_type_patrol_CharacterUpdate(aref chr, float dltTime)
 	// Lugger: Ебьба -->
 	string food = "";
 	float dfood;
-	if(LAi_GetCharacterEnergy(chr) < 25)
+	if(LAi_GetCharacterEnergy(chr) < LAi_GetCharacterMaxEnergy(chr) / 2)
 	{
 		dfood = LAi_GetCharacterMaxEnergy(chr) - LAi_GetCharacterEnergy(chr);
 		food = FindFoodForCharacter(chr, dfood);

--- a/Program/loc_ai/types/LAi_warrior.c
+++ b/Program/loc_ai/types/LAi_warrior.c
@@ -121,7 +121,7 @@ void LAi_type_warrior_CharacterUpdate(aref chr, float dltTime)
 	// Lugger: Ебьба -->
 	string food = "";
 	float dfood;
-	if(LAi_GetCharacterEnergy(chr) < 25)
+	if(LAi_GetCharacterEnergy(chr) < LAi_GetCharacterMaxEnergy(chr) / 2)
 	{
 		dfood = LAi_GetCharacterMaxEnergy(chr) - LAi_GetCharacterEnergy(chr);
 		food = FindFoodForCharacter(chr, dfood);


### PR DESCRIPTION
Запретил НПЦ без кулдауна использовать еду, изменил порог использования, подумал, что с половины лучше будет. Пытался сделать по уму, то есть найти самую сытную еду и от её восстановления смотреть, но слишком нагруженный код получается. И пофиксил очередь.