### PR TITLE
speed from sail damage+fast repair fix

### DIFF
--- a/Program/SEA_AI/AIShip.c
+++ b/Program/SEA_AI/AIShip.c
@@ -3634,7 +3634,8 @@ void Ship_UpdateParameters()
 	// boal кэш оптимизация -->
 	if (!CheckAttribute(rCharacter, "Tmp.SpeedRecall") || sti(rCharacter.Tmp.SpeedRecall) <= 0)
 	{
-		fShipSpeed    = FindShipSpeed(rCharacter);
+		float fTRFromSailDamage = Bring2Range(0.1, 1.0, 0.1, 100.0, stf(rCharacter.ship.sp)); //0.3
+		fShipSpeed    = FindShipSpeed(rCharacter) / fTRFromSailDamage;//убирает движковое дублирование расчета скорости от урона по парусам
 		fShipTurnRate = FindShipTurnRate(rCharacter);
 
 		rCharacter.Tmp.SpeedRecall   = 8 + rand(5);

--- a/Program/battle_interface/BattleInterface.c
+++ b/Program/battle_interface/BattleInterface.c
@@ -2881,7 +2881,7 @@ bool CheckInstantRepairCondition(ref chref)
 	float chrShipSP = GetSailPercent(chref);
 
 	bool bYesHPRepair = chrShipHP < InstantRepairRATE;// boal 23.01.2004
-	bool bYesSPRepair = chrShipSP < InstantRepairRATEsail; //bestreducer быстрая починка// boal 23.01.2004
+	bool bYesSPRepair = chrShipSP < InstantRepairRATE; // boal 23.01.2004
 
 	if( bYesHPRepair )	{ bYesHPRepair = GetCargoGoods(chref,GOOD_PLANKS)>0; }
 	if( bYesSPRepair )	{ bYesSPRepair = GetCargoGoods(chref,GOOD_SAILCLOTH)>0; }

--- a/Program/battle_interface/utils.c
+++ b/Program/battle_interface/utils.c
@@ -16,7 +16,6 @@ native int ShipSailState(int chrIdx);
 #define BI_FAST_REPAIR_PERCENT	1.0
 #define BI_FAST_REPAIR_SAIL		3.0
 #define BI_FAST_REPAIR_PERIOD	50
-#define InstantRepairRATESAIL	78.0
 
 #event_handler("evntActionRepair","procActionRepair");
 
@@ -155,7 +154,7 @@ void procActionRepair()
 			}*/
 			ProcessHullRepairDigital(chref,fRepairH);
 		}
-		if(spp < InstantRepairRATESAIL && nMaterialS>0) // boal 23.01.2004
+		if(spp < InstantRepairRATE && nMaterialS>0) // boal 23.01.2004
 		{
 			//fRepairS = ProcessSailRepairFast(chref,fRepairS);
 			//Log_Info("fRepairS "+chref.ship.Repair+"GetSailPercent(chref) "+chref.ship.SP);
@@ -177,28 +176,37 @@ void procActionRepair()
 			if(fRepairS > 0)
 				chref.ship.RepairS = ProcessSailRepairFast(chref, fRepairS);
 				//Log_Info("chref.ship.RepairS "+chref.ship.RepairS);
-			if(CheckOfficersPerk(chref, "Builder"))
+			if(fRepairS != stf(chref.ship.RepairS))
 			{
-				ftmp2 = BI_FAST_REPAIR_PERCENT*0.9;
-				if(!CheckAttribute(chref, "ship.MatDeltaS"))
-					chref.ship.MatDeltaS = 0.01;
-				ftmp2 += stf(chref.ship.MatDeltaS);
-				if(ftmp2 >= 1)
+				if(CheckOfficersPerk(chref, "Builder"))
 				{
-					nMatDeltaS = ftmp2;
-					//Log_Info("nMatDeltaS "+nMatDeltaS+" ftmp1 "+ftmp1);
-					ftmp2 -= nMatDeltaS;
+					ftmp2 = BI_FAST_REPAIR_PERCENT*0.9;
+					if(!CheckAttribute(chref, "ship.MatDeltaS"))
+						chref.ship.MatDeltaS = 0.01;
+					ftmp2 += stf(chref.ship.MatDeltaS);
+					if(ftmp2 >= 1)
+					{
+						nMatDeltaS = ftmp2;
+						//Log_Info("nMatDeltaS "+nMatDeltaS+" ftmp1 "+ftmp1);
+						ftmp2 -= nMatDeltaS;
+					}
+					chref.ship.MatDeltaS = ftmp2;
 				}
-				chref.ship.MatDeltaS = ftmp2;
+				else
+				{
+					nMatDeltaS = BI_FAST_REPAIR_PERCENT;
+				}
 			}
 			else
-				nMatDeltaS = BI_FAST_REPAIR_PERCENT;
+			{
+				nMatDeltaS = 0;
+			}
 			//Log_Info("nMatDeltaS "+nMatDeltaS);
 			//if(fRepairS>BI_FAST_REPAIR_PERCENT)
 			//	{fRepairS=BI_FAST_REPAIR_PERCENT;}
 			//Log_Info("ремонт "+ fRepairS + " nMatDeltaS " + nMatDeltaS + "fMaterialS" + fMaterialS);
 			/*старое
-			fRepairS = InstantRepairRATESAIL -spp; // boal 23.01.2004
+			fRepairS = InstantRepairRATE -spp; // boal 23.01.2004
 			if(fRepairS>BI_FAST_REPAIR_PERCENT)	{fRepairS=BI_FAST_REPAIR_PERCENT;}
 			ftmp1 = GetSailSPP(chref)*5; //*1
 			ftmp2 = fMaterialS + ftmp1*fRepairS;
@@ -250,7 +258,7 @@ void procActionRepair()
 			}
 			else
 			{
-				if(spp < InstantRepairRATESAIL) // boal 23.01.2004
+				if(spp < InstantRepairRATE) // boal 23.01.2004
 				{	PostEvent("evntActionRepair",BI_FAST_REPAIR_PERIOD,"llff",chrIdx,1, fMaterialH,fMaterialS);
 				}
 				else


### PR DESCRIPTION
Instant repair now skips un-repairable sails while repairing. Removed speed penalty duplication from sail damage. Reverted back to 65% instant repair value to sails.