### PR TITLE
твики мачт+фиксы парусов

### DIFF
--- a/Program/SEA_AI/AIShip.c
+++ b/Program/SEA_AI/AIShip.c
@@ -456,12 +456,12 @@ float Ship_MastDamage()
 	switch (iDamageType)
 	{
 		case SHIP_MAST_TOUCH_ISLAND:
-			fDamage = fDamage + 0.1;
+			fDamage = fDamage + 0.02;
 		break;
 		case SHIP_MAST_TOUCH_SHIP:
 			//aref rCollideCharacter = GetEventData();
 
-			fDamage = fDamage + 0.1;
+			fDamage = fDamage + 0.02;
 		break;
 		case SHIP_MAST_TOUCH_BALL:
 		    //#20171230-01 Mast damage mod
@@ -470,7 +470,7 @@ float Ship_MastDamage()
            	ref rCannon = GetCannonByType(sti(AIBalls.CurrentBallCannonType));
 			int	iBallType = sti(AIBalls.CurrentBallType);
 			int nCaliber = sti(rCannon.caliber);
-			//<---- Lipsar резист урона мачтам от калибра и класса
+			/*//<---- Lipsar резист урона мачтам от калибра и класса
 			int iXmark = 0;
 			switch(nCaliber)
 			{
@@ -511,21 +511,21 @@ float Ship_MastDamage()
 			{
 				iResist = 1.0/(iClass-iXmark);
 			}
-		//<---- Lipsar резист урона мачтам от калибра и класса
-            float nDirect = 0.35; //Glancing
+		//<---- Lipsar резист урона мачтам от калибра и класса*/
+            float nDirect = 0.45; //Glancing
             int nKni = nCaliber;
             if(iBallType == GOOD_KNIPPELS)
-                nKni += 5;
-            if(rand(65) < nKni)
-                nDirect = 1.1; //Direct
-            float fCbrMDamage = 0.5 * retMin(makefloat(nCaliber) / MAX_CAL_MAST_DMG, 1.0);
-            float fClsMDamage = 0.005 * (nClass / 6);
+                nKni = (nKni + 7) * 1.2;
+            if(rand(130 - nClass*15) < nKni)//20% ok 30% good 50+% penetrate
+                nDirect = 1.4; //Direct
+            float fCbrMDamage = retMin(makefloat(nCaliber) / MAX_CAL_MAST_DMG, 1.0);
+            float fClsMDamage = 0.02 * (nClass / 6);
             float tempDamage = 0.0;
             float baseDamage = 0.0;
 			switch (iBallType)
 			{
 				case GOOD_BALLS:
-					baseDamage = pow(nClass, 2.0) * 0.005; //0.025;
+					baseDamage = pow((nClass+1), 2.4) * 0.008; //pow(nClass, 2.0) * 0.005; //0.025; - больше зависимость класса, меньше изначальный урон.
 				break;
 				case GOOD_GRAPES:
 					baseDamage = 0.0;
@@ -533,14 +533,35 @@ float Ship_MastDamage()
 					fClsMDamage = 0.0;
 				break;
 				case GOOD_KNIPPELS:
-					baseDamage = pow(nClass, 2.0) * 0.0035; //0.015;
+					baseDamage = pow((nClass+1), 2.4) * 0.0066; //0.015;
 				break;
 				case GOOD_BOMBS:
-					baseDamage = pow(nClass, 2.0) * 0.0015; //0.005;
+					baseDamage = pow((nClass+1), 2.4) * 0.0025; //0.005;
 				break;
 			}
 			tempDamage = baseDamage * fCbrMDamage + fClsMDamage;
 			tempDamage = tempDamage * nDirect;
+			//может выдержать попаданий в своем классе: I ~120 hits II 50 III 33 IV 25 V 20
+			// LEO: Общий дамаг по мачтам разделен на классы
+			string sShip = rBaseShip.BaseName;
+			if (sShip == "PRINCE" || sShip == "OXFORD" || sShip == "RESOLUTION" || sShip == "MORDAUNT") 
+				tempDamage = tempDamage * MastMulti * 0.8; //для хрупких кораблей сделать жирнее мачты
+			tempDamage = tempDamage * MastMulti;
+			switch (iMastNum)
+			{
+				case 1:
+					tempDamage *= 1.35
+				break;
+				case 2:
+					tempDamage *= 1
+				break;
+				case 3:
+					tempDamage *= 1.2
+				break;
+				case 4:
+					tempDamage *= 2
+				break;
+			}
 			fDamage = fDamage + tempDamage;
         //#20190113-06
         int iBallCharacterIndex = GetEventData();
@@ -566,12 +587,8 @@ float Ship_MastDamage()
 		rCharacter.Tmp.SpeedRecall = 0; // чтоб пересчитался маневр
 		RefreshBattleInterface();
 	}
-
-	// LEO: Общий дамаг по мачтам разделен на классы
-	string sShip = rBaseShip.BaseName;
-	if (sShip == "PRINCE" || sShip == "OXFORD" || sShip == "RESOLUTION" || sShip == "MORDAUNT") return fDamage*MastMulti*0.8; //для хрупких кораблей сделать жирнее мачты
-	fDamage = fDamage * MastMulti;
-	return fDamage*iResist;
+	Log_TestInfo("Damage "+fDamage+" Mast "+iMastNum);
+	return fDamage;
 	//procMastFall
 }
 

--- a/Program/SEA_AI/AIShip.c
+++ b/Program/SEA_AI/AIShip.c
@@ -470,7 +470,8 @@ float Ship_MastDamage()
            	ref rCannon = GetCannonByType(sti(AIBalls.CurrentBallCannonType));
 			int	iBallType = sti(AIBalls.CurrentBallType);
 			int nCaliber = sti(rCannon.caliber);
-			/*//<---- Lipsar резист урона мачтам от калибра и класса
+			/*
+			//<---- Lipsar резист урона мачтам от калибра и класса
 			int iXmark = 0;
 			switch(nCaliber)
 			{
@@ -511,21 +512,22 @@ float Ship_MastDamage()
 			{
 				iResist = 1.0/(iClass-iXmark);
 			}
-		//<---- Lipsar резист урона мачтам от калибра и класса*/
+		//<---- Lipsar резист урона мачтам от калибра и класса
+		*/
             float nDirect = 0.45; //Glancing
             int nKni = nCaliber;
             if(iBallType == GOOD_KNIPPELS)
-                nKni = (nKni + 7) * 1.2;
-            if(rand(130 - nClass*15) < nKni)//20% ok 30% good 50+% penetrate
-                nDirect = 1.4; //Direct
+                nKni = (nKni + 8) * 1.6;
+            if(rand(200 - nClass*25) < nKni)//20% ok 30% good 50+% penetrate
+                nDirect = 1.3; //Direct
             float fCbrMDamage = retMin(makefloat(nCaliber) / MAX_CAL_MAST_DMG, 1.0);
-            float fClsMDamage = 0.02 * (nClass / 6);
+            float fClsMDamage = 0.03 * (nClass / 6);
             float tempDamage = 0.0;
             float baseDamage = 0.0;
 			switch (iBallType)
 			{
 				case GOOD_BALLS:
-					baseDamage = pow((nClass+1), 2.4) * 0.005; //pow(nClass, 2.0) * 0.005; //0.025; - больше зависимость класса, меньше изначальный урон.
+					baseDamage = pow((nClass+1), 1.8) * 0.015; //* 0.005; //0.025;
 				break;
 				case GOOD_GRAPES:
 					baseDamage = 0.0;
@@ -533,10 +535,10 @@ float Ship_MastDamage()
 					fClsMDamage = 0.0;
 				break;
 				case GOOD_KNIPPELS:
-					baseDamage = pow((nClass+1), 2.4) * 0.0043; //0.015;
+					baseDamage = pow((nClass+1), 1.8) * 0.015; //0.015;
 				break;
 				case GOOD_BOMBS:
-					baseDamage = pow((nClass+1), 2.4) * 0.001; //0.005;
+					baseDamage = pow((nClass+1), 1.8) * 0.003; //0.005;
 				break;
 			}
 			tempDamage = baseDamage * fCbrMDamage + fClsMDamage;
@@ -550,22 +552,24 @@ float Ship_MastDamage()
 			switch (iMastNum)
 			{
 				case 1:
-					tempDamage *= 1.35
+					tempDamage *= 1.5
 				break;
 				case 2:
-					tempDamage *= 1
+					tempDamage *= 1.0
 				break;
 				case 3:
-					tempDamage *= 1.2
+					tempDamage *= 0.8
 				break;
 				case 4:
 					tempDamage *= 2
 				break;
 			}
-			fDamage = fDamage + tempDamage;
-        //#20190113-06
         int iBallCharacterIndex = GetEventData();
         ref rBallCharacter = GetCharacter(iBallCharacterIndex);
+		float fDistance = Ship_GetDistance2D(rCharacter, rBallCharacter);
+		tempDamage = tempDamage * Bring2Range(1.1, 0.2, 0.0, makefloat(GetShootDistance(rBallCharacter, iBallType)), fDistance);
+		fDamage = fDamage + tempDamage;
+        //#20190113-06
         if(GetNationRelation(sti(rBallCharacter.Nation), sti(rCharacter.nation)) != RELATION_FRIEND)
 			{
 				if(CheckAttribute(rCharacter, "SeaAI.fortSanctuary"))
@@ -587,7 +591,7 @@ float Ship_MastDamage()
 		rCharacter.Tmp.SpeedRecall = 0; // чтоб пересчитался маневр
 		RefreshBattleInterface();
 	}
-	Log_TestInfo("Damage "+fDamage+" Mast "+iMastNum);
+	//Log_TestInfo("Damage "+fDamage+" Mast "+iMastNum);
 	return fDamage;
 	//procMastFall
 }

--- a/Program/SEA_AI/AIShip.c
+++ b/Program/SEA_AI/AIShip.c
@@ -470,56 +470,12 @@ float Ship_MastDamage()
            	ref rCannon = GetCannonByType(sti(AIBalls.CurrentBallCannonType));
 			int	iBallType = sti(AIBalls.CurrentBallType);
 			int nCaliber = sti(rCannon.caliber);
-			/*
-			//<---- Lipsar резист урона мачтам от калибра и класса
-			int iXmark = 0;
-			switch(nCaliber)
-			{
-				case 8:
-					iXmark = 8;
-				break;
-				case 12:
-					iXmark = 5;
-				break;
-				case 16:
-					iXmark = 5;
-				break;
-				case 20:
-					iXmark = 5;
-				break;
-				case 24:
-					iXmark = 2;
-				break;
-				case 32:
-					iXmark = 1;
-				break;
-				case 36:
-					iXmark = 1;
-				break;
-				case 42:
-					iXmark = 0;
-				break;
-				case 48:
-					iXmark = 0;
-				break;
-			}
-			float iResist = 1;
-			if(iXmark > iClass)
-			{
-				iResist = 1 + 1.0 / (iXmark - iClass);
-			}
-			else
-			{
-				iResist = 1.0/(iClass-iXmark);
-			}
-		//<---- Lipsar резист урона мачтам от калибра и класса
-		*/
-            float nDirect = 0.45; //Glancing
+			float nDirect = 0.45; //Glancing
             int nKni = nCaliber;
             if(iBallType == GOOD_KNIPPELS)
                 nKni = (nKni + 8) * 1.6;
             if(rand(200 - nClass*25) < nKni)//20% ok 30% good 50+% penetrate
-                nDirect = 1.3; //Direct
+                nDirect = 1.3; 
             float fCbrMDamage = retMin(makefloat(nCaliber) / MAX_CAL_MAST_DMG, 1.0);
             float fClsMDamage = 0.03 * (nClass / 6);
             float tempDamage = 0.0;
@@ -527,7 +483,7 @@ float Ship_MastDamage()
 			switch (iBallType)
 			{
 				case GOOD_BALLS:
-					baseDamage = pow((nClass+1), 1.8) * 0.015; //* 0.005; //0.025;
+					baseDamage = pow((nClass+1), 1.8) * 0.015; //* 0.005;Leo //0.025;
 				break;
 				case GOOD_GRAPES:
 					baseDamage = 0.0;
@@ -543,8 +499,6 @@ float Ship_MastDamage()
 			}
 			tempDamage = baseDamage * fCbrMDamage + fClsMDamage;
 			tempDamage = tempDamage * nDirect;
-			//может выдержать попаданий в своем классе: I ~120 hits II 50 III 33 IV 25 V 20
-			// LEO: Общий дамаг по мачтам разделен на классы
 			string sShip = rBaseShip.BaseName;
 			if (sShip == "PRINCE" || sShip == "OXFORD" || sShip == "RESOLUTION" || sShip == "MORDAUNT") 
 				tempDamage = tempDamage * MastMulti * 0.8; //для хрупких кораблей сделать жирнее мачты
@@ -591,7 +545,6 @@ float Ship_MastDamage()
 		rCharacter.Tmp.SpeedRecall = 0; // чтоб пересчитался маневр
 		RefreshBattleInterface();
 	}
-	//Log_TestInfo("Damage "+fDamage+" Mast "+iMastNum);
 	return fDamage;
 	//procMastFall
 }

--- a/Program/SEA_AI/AIShip.c
+++ b/Program/SEA_AI/AIShip.c
@@ -525,7 +525,7 @@ float Ship_MastDamage()
 			switch (iBallType)
 			{
 				case GOOD_BALLS:
-					baseDamage = pow((nClass+1), 2.4) * 0.008; //pow(nClass, 2.0) * 0.005; //0.025; - больше зависимость класса, меньше изначальный урон.
+					baseDamage = pow((nClass+1), 2.4) * 0.005; //pow(nClass, 2.0) * 0.005; //0.025; - больше зависимость класса, меньше изначальный урон.
 				break;
 				case GOOD_GRAPES:
 					baseDamage = 0.0;
@@ -533,10 +533,10 @@ float Ship_MastDamage()
 					fClsMDamage = 0.0;
 				break;
 				case GOOD_KNIPPELS:
-					baseDamage = pow((nClass+1), 2.4) * 0.0066; //0.015;
+					baseDamage = pow((nClass+1), 2.4) * 0.0043; //0.015;
 				break;
 				case GOOD_BOMBS:
-					baseDamage = pow((nClass+1), 2.4) * 0.0025; //0.005;
+					baseDamage = pow((nClass+1), 2.4) * 0.001; //0.005;
 				break;
 			}
 			tempDamage = baseDamage * fCbrMDamage + fClsMDamage;

--- a/Program/battle_interface/BattleInterface.c
+++ b/Program/battle_interface/BattleInterface.c
@@ -2451,7 +2451,6 @@ ref ProcessSailDamage()
 		arSail.hc = holeCount;
 		arSail.oldhd = holeData;
 	}
-	//Log_Info("NewHitCount "+arSail.NewHitCount+", HoleCount "+holeCount+", sailDmg "+sailDmg+", defendedCount "+arSail.defended);
 	
 	arSail.mhc = maxHoleCount;
 	arSail.sp = sailPower;

--- a/Program/battle_interface/BattleInterface.c
+++ b/Program/battle_interface/BattleInterface.c
@@ -2364,29 +2364,38 @@ ref ProcessSailDamage()
 	float sailPower = GetEventData();
 
 	ref chref = GetCharacter(chrIdx);
-	if (CheckAttribute(&RealShips[sti(chref.Ship.Type)], "Tuning.SailsSpecial") && rand(2)<1)
-	{
-		BI_g_fRetVal = 0;
-		return &BI_g_fRetVal;
-	}
-
-	if (LAi_IsImmortal(chref))
-	{
-		BI_g_fRetVal = 0;
-		return &BI_g_fRetVal;
-	}
 
 	string groupName = ""+groupNum;
 	aref arSail;
 	makearef(arSail,chref.ship.sails.(reyName).(groupName));
+	
+	if (LAi_IsImmortal(chref))
+	{
+		arSail.hd = DeleteOneSailHole(sti(chref.index), groupName, reyName, holeData, 1);//имитирует защиту залатыванием дырки в месте попадания
+		BI_g_fRetVal = 0;
+		return &BI_g_fRetVal;
+	}
 
 	float sailDmg = 0.0;
 	float sailDmgMax = GetCharacterShipSP(chref) * sailPower;
+	if(!CheckAttribute(arSail, "oldhd"))
+	{
+		arSail.oldhd = 0;
+	}
+	if(!CheckAttribute(arSail, "olddmg"))
+	{
+		arSail.olddmg = 0;
+	}
+	if(!CheckAttribute(arSail, "oldhc")) 
+	{
+		arSail.oldhc = 0;
+	}
 	if( !CheckAttribute(arSail,"dmg") )	{ sailDmg = 0.0; }
-
+	
 	if(sMastName=="*")
 	{
-		sailDmg = sailDmg + GetRigDamage(shootIdx,sti(AIBalls.CurrentBallType),chref);
+		//sailDmg = sailDmg + GetRigDamage(shootIdx,sti(AIBalls.CurrentBallType),chref);
+		//RigDamage тут всегда 0
 		if(sailDmg>sailDmgMax)	{ sailDmg = sailDmgMax; }
 		int needHole = GetNeedHoleFromDmg(sailDmg,sailDmgMax,maxHoleCount);
 		if(holeCount!=needHole)
@@ -2401,6 +2410,7 @@ ref ProcessSailDamage()
 				sailDmg = GetNeedDmgFromHole(holeCount,sailDmgMax,maxHoleCount);
 			}
 		}
+		sailDmg = GetNeedDmgFromHole(holeCount,sailDmgMax,maxHoleCount);
 	}
 	else
 	{
@@ -2412,13 +2422,41 @@ ref ProcessSailDamage()
 	{
 		Log_SetStringtoLog("MUST DIE!!! " + sailDmg);
 	}*/
+	
+	if(CheckAttribute(&RealShips[sti(chref.Ship.Type)], "Tuning.SailsSpecial") && rand(5)<1 && holedata != sti(arSail.oldhd))
+	{
 
-	arSail.hc = holeCount;
-	arSail.hd = holeData;
+		if(sailDmg - stf(arSail.olddmg) >=1)
+		{
+			arSail.hd = DeleteOneSailHole(sti(chref.index), groupName, reyName, holeData, 1);
+			arSail.oldhd = sti(arSail.hd);
+			if(!CheckAttribute(arSail, "defended"))
+			{
+				arSail.defended = 1;
+			}	
+			arSail.defended = sti(arSail.defended)+1;
+			arSail.hc = sti(arSail.oldhc);
+			arSail.oldhc = sti(arSail.hc);
+			arSail.dmg = stf(arSail.olddmg);
+			arSail.olddmg = stf(arSail.dmg);
+			chref.ship.SP = CalculateShipSP(chref);
+			BI_g_fRetVal = 0.0;
+			return &BI_g_fRetVal;
+		}
+	}
+	else
+	{
+		arSail.dmg = sailDmg;
+		arSail.hd = holeData;
+		arSail.hc = holeCount;
+		arSail.oldhd = holeData;
+	}
+	//Log_Info("NewHitCount "+arSail.NewHitCount+", HoleCount "+holeCount+", sailDmg "+sailDmg+", defendedCount "+arSail.defended);
+	
 	arSail.mhc = maxHoleCount;
 	arSail.sp = sailPower;
-	arSail.dmg = sailDmg;
 
+	
 	chref.ship.SP = CalculateShipSP(chref);
 	BI_g_fRetVal = sailDmg;
 	return &BI_g_fRetVal;

--- a/Program/battle_interface/utils.c
+++ b/Program/battle_interface/utils.c
@@ -105,13 +105,9 @@ void procActionRepair()
 			iRepair++;
 		if(chref.Fellows.Passengers.carpenter > 0)
 			iRepair++;
-		//ftmp1 = GetCharacterShipHP(chref);
-		//ftmp2 = stf(chref.Ship.HP)*InstantRepairRATE*0.01;//макс хп * InstantRepairRATE из _mod_on_off.c
-		if(hpp < InstantRepairRATE && nMaterialH > 0)//if(hpp < InstantRepairRATE && nMaterialH>0) // boal 23.01.2004
+		if(hpp < InstantRepairRATE && nMaterialH > 0)// boal 23.01.2004
 		{
-			//Log_Info(" carpenter "+chref.Fellows.Passengers.carpenter);
-			//Log_Info("Скорость ремонта "+iRepair);
-			//iRepair = MakeInt(iRepair);
+
 			fRepairH = makefloat(iRepair*BI_FAST_REPAIR_PERCENT);
 			if(CheckOfficersPerk(chref, "Carpenter"))
 				fRepairH *= 1.1;
@@ -124,7 +120,6 @@ void procActionRepair()
 				if(ftmp1 >= 1)
 				{
 					nMatDeltaH = ftmp1;
-					//Log_Info("nMatDeltaH "+nMatDeltaH+" ftmp1 "+ftmp1);
 					ftmp1 -= nMatDeltaH;
 				}
 				chref.ship.MatDelta = ftmp1;
@@ -157,12 +152,6 @@ void procActionRepair()
 		}
 		if(spp < InstantRepairRATE && nMaterialS>0) // boal 23.01.2004
 		{
-			//fRepairS = ProcessSailRepairFast(chref,fRepairS);
-			//Log_Info("fRepairS "+chref.ship.Repair+"GetSailPercent(chref) "+chref.ship.SP);
-			//else{chref.ship.Repair = 1;}
-			//Log_Info("fRepairS "+chref.ship.Repair);
-			//bool allow = CalculateShipSP(chref) >= GetSailPercent(chref);
-			//Log_Info("chref.ship.scriptsp "+chref.ship.scriptsp+" chref.ship.sp "+chref.ship.sp);
 			ftmp1 = GetCharacterShipClass(chref);//замедление починки парусов от класса выше 5
 			if(ftmp1 < 5)
 				ftmp1 = (6 - ftmp1);//первоклассник в 5 раз
@@ -171,14 +160,12 @@ void procActionRepair()
 			if(!CheckAttribute(chref, "chref.ship.RepairS"))
 				chref.ship.RepairS = 0.01;
 			fRepairS = stf(chref.ship.RepairS);
-			fRepairS += (BI_FAST_REPAIR_PERCENT*iRepair*BI_FAST_REPAIR_SAIL*(1+0.1*CheckOfficersPerk(chref, "Carpenter"))) / (stf(rBaseShip.SP) * ftmp1);//тут происходит основной расчет ремонта - доп.модификатор скорости ремонта * бонус навыка * опорное число * бонус перка плотник / макс состояние парусов * модификатор класса
+			fRepairS += (BI_FAST_REPAIR_PERCENT*iRepair*BI_FAST_REPAIR_SAIL*(1+0.1*CheckOfficersPerk(chref, "Carpenter"))) / (stf(rBaseShip.SP) * ftmp1);//расчет ремонта - доп.модификатор скорости ремонта * бонус навыка * опорное число * бонус перка плотник / макс состояние парусов * модификатор класса
 			chref.ship.RepairS = fRepairS;
-			//Log_Info("chref.ship.sp "+chref.ship.sp+" chref.ship.RepairS "+chref.ship.RepairS);
 			if(fRepairS > 0)
 			{
 				chref.ship.RepairS = ProcessSailRepairFast(chref, fRepairS);
 			}
-			//Log_Info("chref.ship.RepairS "+chref.ship.RepairS+", fRepairS "+fRepairS);
 			if((fRepairS - 0.000003) > stf(chref.ship.RepairS))//при операциях с движком переменные получают 0.000000003
 			{
 				if(CheckOfficersPerk(chref, "Builder"))
@@ -190,7 +177,6 @@ void procActionRepair()
 					if(ftmp2 >= 1)
 					{
 						nMatDeltaS = ftmp2;
-						//Log_Info("nMatDeltaS "+nMatDeltaS+" ftmp1 "+ftmp1);
 						ftmp2 -= nMatDeltaS;
 					}
 					chref.ship.MatDeltaS = ftmp2;
@@ -204,10 +190,6 @@ void procActionRepair()
 			{
 				nMatDeltaS = 0;
 			}
-			//Log_Info("nMatDeltaS "+nMatDeltaS);
-			//if(fRepairS>BI_FAST_REPAIR_PERCENT)
-			//	{fRepairS=BI_FAST_REPAIR_PERCENT;}
-			//Log_Info("ремонт "+ fRepairS + " nMatDeltaS " + nMatDeltaS + "fMaterialS" + fMaterialS);
 			/*старое
 			fRepairS = InstantRepairRATE -spp; // boal 23.01.2004
 			if(fRepairS>BI_FAST_REPAIR_PERCENT)	{fRepairS=BI_FAST_REPAIR_PERCENT;}
@@ -246,14 +228,6 @@ void procActionRepair()
 			chref.Ship.Cargo.Goods.(goodsName) = nMaterialS;
 			chref.Ship.Cargo.Load = sti(chref.Ship.Cargo.Load) - sti(Goods[GOOD_SAILCLOTH].Weight)*nMatDeltaS;
 		}
-		/*if(GetOfficersPerkUsingIdx(chref, "InstantRepair") > 0)
-			{repairAllow = true;}
-		else
-		{
-			if(!bAltBalance && chref.perks.list.InstantRepair.active > 0)
-			{repairAllow = true}
-		}*/
-		//Log_Info("CheckOfficersPerk "+CheckOfficersPerk(chref, "InstantRepair"));
 		if (CheckOfficersPerk(chref, "InstantRepair"))
 		{
 			if((hpp < InstantRepairRATE)) // boal 23.01.2004
@@ -300,16 +274,11 @@ float ProcessHullRepair(ref chref,float repPercent)
 float ProcessHullRepairDigital(ref chref,float Digit)
 {
 	int baseHP = GetCharacterShipHP(chref);
-	//Log_Info("baseHP " + baseHP);
-	//Log_Info("Digit " + Digit);
 	int dmg = baseHP - sti(chref.ship.HP);
-	//Log_Info("dmg " + dmg);
-	//Log_Info("chref.ship.HP " + chref.ship.HP);
 	if(dmg==0.0) return 0.0;
 	if(Digit>dmg) Digit=dmg;
 	int blotsQuantity = GetBlotsQuantity(chref);
 	int repBlots = makeint(blotsQuantity*Digit/dmg);
-	//Log_Info("repBlots "+repBlots);
 	DeleteBlots(chref,repBlots);
 	chref.ship.HP = makefloat(baseHP+Digit-dmg);
 	return Digit;
@@ -371,8 +340,6 @@ float ProcessSailRepair(ref chref, float repPercent)
 float ProcessSailRepairFast(ref chref, float fMakeRepair)
 {
 	float dmg = 100.0-GetSailPercent(chref);
-	//if(dmg==0.0) return 0.0;
-	//if(repPercent>dmg) repPercent=dmg;
 	int i,j,rq,gq;
 	aref arRoot,arGroup,arSail;
 	string tmpstr;
@@ -400,7 +367,6 @@ float ProcessSailRepairFast(ref chref, float fMakeRepair)
 				float sailDmgMax = GetCharacterShipSP(chref) * stf(arSail.sp);
 				if(fMakeRepair<=0.0)
 					break;
-				//Log_Info("ремонт: " + fMakeRepair + " повреждение " + fSailDmg);
 				if (fSailDmg <= 0.0 || !CheckAttribute(arSail, "hd"))
 					continue;  // fix boal 14.09.06
 
@@ -415,7 +381,6 @@ float ProcessSailRepairFast(ref chref, float fMakeRepair)
 				fSailDmg -= fMakeRepair;
 				int iAfterHole = GetNeedHoleFromDmg( fSailDmg, sailDmgMax, sti(arSail.mhc) );
 				fMakeRepair += (MakeFloat(iAfterHole)/stf(arSail.mhc))*sailDmgMax - fSailDmg/stf(arSail.sp);//получение значения починки после починки движком
-				//Log_Info("fMakeRepair "+fMakeRepair+" fAfterHole "+fAfterHole+" fSailDmg "+fSailDmg);
 				if( sti(arSail.hc) > iAfterHole )
 				{
 					arSail.hd = DeleteOneSailHole( sti(chref.index), GetAttributeName(arSail), GetAttributeName(arGroup), sti(arSail.hd), sti(arSail.hc)-iAfterHole );
@@ -440,7 +405,6 @@ float ProcessSailRepairFast(ref chref, float fMakeRepair)
 			i--;
 		}
 	}
-	//chref.ship.RepairS = fMakeRepair;
 	chref.ship.sp = CalculateShipSP(chref);
 	return fMakeRepair;
 }

--- a/RESOURCE/INI/rigging.ini
+++ b/RESOURCE/INI/rigging.ini
@@ -45,9 +45,14 @@ Power		= 0.5
 
 ; SPEED CALCULATE PARAMETERS
 fHoleDepend		= 1.0
-TreangleWindSpeed	= 0.2,0.6,0.8
-TrapecidalWindSpeed	= 0.4,0.5,0.6
-SquareWindSpeed		= 0.4,0.1,0.6
+; flat, beidewind, fordewind
+TreangleWindSpeed	= 0.25,0.55,0.6
+;0.2,0.6,0.8 
+TrapecidalWindSpeed	= 0.25,0.55,0.6
+;0.35,0.5,0.6 
+SquareWindSpeed		= 0.25,0.0,0.7
+;0.4,0.1,0.6
+
 
 ; ROLLING SAIL PARAMETERS
 ; square sail rolling


### PR DESCRIPTION
- скорректированы значения скорости парусов от ветра, чтобы косопарусники не были медленнее или быстрее прямопарусников при том же параметре скорости
- апгрейд "укрепленные паруса" теперь действительно уменьшает урон в паруса (могут быть заметны дергания полоски парусов)
- Быстрая починка с упавшими мачтами на обновленном движке больше не сыпет ошибками и не вылетает
- Пофикшен урон по мачтам в целом
- добавлен множитель мачты, в зависимости от ее важности, изменен урон. Мачты перво- и второклассников снова тяжело снять(около 25-30 попаданий вместо 10). Усилено влияние книппелей на мачты