### PR TITLE
Фикс менюшек после подбора бочки на боевой.

### DIFF
--- a/Program/INTERFACE/itemsbox.c
+++ b/Program/INTERFACE/itemsbox.c
@@ -546,10 +546,10 @@ void IDoExit(int exitCode)
 
 	csmDA(pchar, "CSM.LootCollector.Run");
 	// CSM <--
-	if (!bLandInterfaceStart)
+	/*if (!bLandInterfaceStart)
 	{
 		StartBattleLandInterface();
-	}
+	}*/
 }
 
 void ProcCommand()


### PR DESCRIPTION
Я не помню, зачем это было сделано. Желательно проверить на всех интерфейсах обмена, что используют itemsbox