### PR TITLE
Починил пикчу Элен

### DIFF
--- a/Program/characters/characters_face.c
+++ b/Program/characters/characters_face.c
@@ -422,6 +422,7 @@ void FaceMaker(aref rCharacter)
 		// ГПК 1.2.5 -->
 		case "PGG_Angellica":	rCharacter.FaceId = 242; break;
 		case "PGG_Rumba":		rCharacter.FaceId = 488; break;
+		case "PGG_Rumba_0":     rCharacter.FaceId = 488; break;
 
 		case "YokoDias":		rCharacter.FaceId = 243; break;
 		case "PGG_YokoDias_0":	rCharacter.FaceId = 243; break;


### PR DESCRIPTION
Это говно только на маелшторме воспроизводилось, но в любом случае надо добавить, а то вдруг чего.

По какой-то причине айди модельки был "PGG_Rumba_0" заместо "PGG_Rumba".

Это если включена галка отображения кирас на "остальных". Теперь понятно почему многие не ловили эту багулю.