### PR TITLE
Оптимизация событий в кадре: Часть 1

### DIFF
--- a/Program/INTERFACE/ship.c
+++ b/Program/INTERFACE/ship.c
@@ -1296,6 +1296,7 @@ void CannonsMenuRefresh()
 		SetFormatedText("CANNONS_QTY_L", "0");
 	}
 	FillCannonsTable();
+	if (IsMainCharacter(xi_refCharacter)) BI_UpdateCannons();
 }
 void ExitCannonsMenu()
 {

--- a/Program/SEA_AI/AICannon.c
+++ b/Program/SEA_AI/AICannon.c
@@ -250,9 +250,10 @@ float Cannon_DamageEvent()
 		CreateBlast(x,y,z);
 		CreateParticleSystem("blast_inv", x, y, z, 0.0, 0.0, 0.0, 0);
 		Play3DSound("cannon_explosion", x, y, z);
-		if (sti(aCharacter.index) == GetMainCharacterIndex())
+		if (IsMainCharacter(aCharacter))
 		{
 		    Log_Info(XI_ConvertString("Cannon_DamageEvent"));
+		    BI_UpdateCannons();
 		}
 		aCharacter.Ship.Cargo.RecalculateCargoLoad = true; // boal 27.07.06 пушки - груз
 	}

--- a/Program/SEA_AI/AIShip.c
+++ b/Program/SEA_AI/AIShip.c
@@ -1067,6 +1067,7 @@ void Ship_ChangeCharge(ref rCharacter, int iNewChargeType)
 	//fix Ship_PlaySound3D(rCharacter, "reloadstart_" + rGood.name, 1.0);
 
 	Ship_ClearBortsReloadedEvent(rCharacter);
+	BI_UpdateLoadedProjectiles(); // обновим иконки и текста заряженных снарядов в BattleInterface
 }
 
 void Ship_OnCreate()


### PR DESCRIPTION
Оптимизировал BattleInterface и покадровый вызов GetCurrentCharge().

Каждый кадр считался дамаг у пушек, а также текста и иконки заряженных снарядов.

Сейчас же, подсчитываться будет только по необходимости, а все остальное время будет брать закешированные подсчеты.