### PR TITLE
Оптимизация событий в кадре: Часть 2

### DIFF
--- a/Program/SEA_AI/AIBalls.c
+++ b/Program/SEA_AI/AIBalls.c
@@ -81,6 +81,7 @@ void Ball_FlyNearCamera()
 
 int ballNumber;
 
+// FPSTODO: метод очень тяжелый, особенно в замесах проседания видны невооруженным глазом
 void Ball_AddBall(aref aCharacter, float fX, float fY, float fZ, float fSpeedV0, float fDirAng, float fHeightAng, float fCannonDirAng, float fMaxFireDistance)
 {
 	int iCannonType = sti(aCharacter.Ship.Cannons.Type);

--- a/Program/SEA_AI/AISea.c
+++ b/Program/SEA_AI/AISea.c
@@ -308,7 +308,7 @@ bool SeaAI_SetOfficer2ShipAfterAbordage(ref refMyCharacter, ref refEnemyCharacte
 	return true;
 }
 
-int SeaAI_GetRelation(int iCharacterIndex1, int iCharacterIndex2)
+int SeaAI_GetRelation(int iCharacterIndex1, int iCharacterIndex2) // FPSTODO: слишком часто вызывается
 {
  	int iRelation = RELATION_NEUTRAL;
 	/*if (bSeaActive)

--- a/Program/SEA_AI/AIShip.c
+++ b/Program/SEA_AI/AIShip.c
@@ -121,11 +121,9 @@ void DeleteShipEnvironment()
 	DelEventHandler("Ship_SailsMoveSound", "Ship_SailsMoveSound");
 	DelEventHandler("Ship_BortReloadEvent", "Ship_BortReloadEvent");
 
-	for (int i=0; i<iNumShips; i++)
-	{
-		// delete particles from ship/etc
-		SendMessage(&Characters[Ships[i]], "l", MSG_SHIP_SAFE_DELETE);
-	}
+	int i = 0;
+	for(i = 0; i < GetArraySize(&LoadedChars); i++) LoadedChars[i] = 0; // clear array of loaded chars on sea
+	for(i = 0; i<iNumShips; i++) SendMessage(&Characters[Ships[i]], "l", MSG_SHIP_SAFE_DELETE); // delete particles from ship/etc
 
 	// scan characters for delete snd id's
 	DeleteEntitiesByType("ship");
@@ -895,6 +893,7 @@ void Ship_Add2Sea(int iCharacterIndex, bool bFromCoast, string sFantomType)
 	}
 
 	Ships[iNumShips] = iCharacterIndex;
+	LoadedChars[iNumShips] = iCharacterIndex; // после загрузки локации в море
 	rCharacter.curshipnum = iNumShips;
 	trace("AIShip  iNumShips : " + iNumShips + " ShipModelrList : " + ShipModelrList[iNumShips] + " ShipName : " + rCharacter.Ship.Name + " Ships = " + Ships[iNumShips]);
 	iNumShips++;
@@ -1879,7 +1878,7 @@ int Ship_FindOtherBallType(ref rCharacter, float fMinEnemyDistance, bool bBalls,
 }
 
 // event: indicate that ball is not enough for fire for main character
-void Ship_NotEnoughBalls()
+void Ship_NotEnoughBalls() // FPSTODO: зачем вызывается так часто?
 {
 	bNotEnoughBalls = GetEventData();
 	// boal -->
@@ -1894,7 +1893,7 @@ void Ship_NotEnoughBalls()
 
 }
 
-int Ship_GetCurrentBallsNum()
+int Ship_GetCurrentBallsNum() // FPSTODO: вызывается каждый кадр, юзать кэш, прибавка минимальна
 {
 	aref aCharacter = GetEventData();
 	return GetCargoGoods(aCharacter,sti(aCharacter.Ship.Cannons.Charge.Type));
@@ -2906,7 +2905,6 @@ void Ship_SetFantomData(ref rFantom)
 	if (CheckAttribute(rFantom, "Ship.Masts")) { DeleteAttribute(rFantom, "Ship.Masts"); }
 	if (CheckAttribute(rFantom, "Ship.Blots")) { DeleteAttribute(rFantom, "Ship.Blots"); }
 	if (CheckAttribute(rFantom, "Ship.Sails")) { DeleteAttribute(rFantom, "Ship.Sails"); }
-
 }
 
 void CharacterUpdateShipFromBaseShip(int iCharacterIndex)
@@ -4159,6 +4157,7 @@ void Ship_LoadShip()
 		ShipModelrList[iNumShips] = GetCurrentModelrNumber();
 
 		Ships[iNumShips] = iCharacterIndex;
+		LoadedChars[iNumShips] = iCharacterIndex; // после загрузки сейва в море
 		rCharacter.curshipnum = iNumShips;
 		Dev_Trace("Ship_LoadShip = " + iCharacterIndex + " id = " + rCharacter.id + " iNumShips = " + iNumShips + " curshipnum = " + rCharacter.curshipnum + " ShipModelrList[iNumShips] = " + ShipModelrList[iNumShips]);
 		Event(SHIP_UPDATE_PARAMETERS, "lf", iCharacterIndex, stf(rCharacter.Ship.Speed.z));		// Parameters      после создания корабля

--- a/Program/SEA_AI/sea.c
+++ b/Program/SEA_AI/sea.c
@@ -1641,7 +1641,8 @@ void Sea_Load()
 	{
 		if(Ships[i] > 0)
 		{
-			chr = GetCharacter(Ships[i]); sTemp = chr.Ship.Name
+			chr = GetCharacter(Ships[i]);
+			sTemp = chr.Ship.Name;
 		}
 		else
 		{

--- a/Program/battle_interface/BattleInterfaceUpdates.c
+++ b/Program/battle_interface/BattleInterfaceUpdates.c
@@ -1,0 +1,120 @@
+int BI_CannonsUpdate = 0;
+int BI_icons_ProjectilesUpdate = 0;
+
+int LoadedChars[MAX_SHIPS_ON_SEA];
+
+void BI_UpdateShipsRollSpeed()
+{
+	ref chref;
+	for (i = 0; i < MAX_SHIPS_ON_SEA; i++)
+	{
+		if (LoadedChars[i] <= 0) continue;
+		chref = GetCharacter(LoadedChars[i])
+		BI_UpdateRSRollSpeed(chref);
+	}
+	PostEvent("BI_CallUpdateShipsRollSpeed", 1000); // once every second, on x1 time
+}
+
+void BI_UpdateRSRollSpeed(ref chref) // скорость подъема/спуска парусов
+{
+	if (HasSubStr(chref.id, "_DriftCap_"))
+	{
+		chref.Ship.RollSpeed = 3.0;
+		return;
+	}
+
+	int iShip = sti(chref.ship.type);
+	if (iShip < 0 || iShip >= REAL_SHIPS_QUANTITY)
+	{
+		chref.Ship.RollSpeed = 0.0;
+		return;
+	}
+
+	int crewQ = GetCrewQuantity(chref);
+	//int crewMin = sti(RealShips[iShip].MinCrew);
+	if (!CheckAttribute(&RealShips[iShip], "MaxCrew"))
+	{
+		Log_TestInfo("GetRSRollSpeed нет MaxCrew у корабля НПС ID=" + chref.id);
+		chref.Ship.RollSpeed = 0.0;
+		return;
+	}
+
+	int crewMax = sti(RealShips[iShip].MaxCrew);
+	int crewOpt = sti(RealShips[iShip].OptCrew);//boal
+	if (crewMax < crewQ) crewQ = crewMax; // boal
+
+	// опыт матросов
+	float  fExp;
+
+	if (crewOpt <= 0) crewOpt = 0; // fix для профилактики деления на ноль
+
+	fExp = 0.05 + stf(GetCrewExp(chref, "Sailors") * crewQ) / stf(crewOpt * GetCrewExpRate());
+	if (fExp > 1) fExp = 1;
+
+	float fRollSpeed = 0.5 + 0.05 * makefloat(GetSummonSkillFromNameToOld(chref, SKILL_SAILING)); //fix skill
+	fRollSpeed = fRollSpeed * fExp;
+
+	// мораль
+	float  fMorale = stf(stf(GetCharacterCrewMorale(chref)) / MORALE_MAX);
+	fRollSpeed = fRollSpeed * (0.7 + fMorale / 2.0);
+
+	if (iArcadeSails != 1) fRollSpeed = fRollSpeed / 2.5;
+	if (CheckOfficersPerk(chref, "SailsMan")) fRollSpeed = fRollSpeed * 1.1; // 10 процентов
+	if (CheckAttribute(&RealShips[iShip], "Tuning.SailsSpecial")) fRollSpeed = fRollSpeed * 1.25;
+
+	chref.Ship.RollSpeed = fRollSpeed;
+}
+
+void BI_UpdateLoadedProjectiles()
+{  // обновление иконок и текстов в BattleInterface
+	if (!CheckAttribute(pchar, "Ship.Cannons.Charge.Type"))
+	{
+		trace("ОШИБКА: Не нашли Ship.Cannons.Charge.Type для ГГ")
+			return;
+	}
+
+	switch (sti(pchar.Ship.Cannons.Charge.Type))
+	{
+	case GOOD_BALLS:
+		BI_icons_ProjectilesUpdate = 32;
+		BattleInterface.textinfo.Ammo.text = "" + sti(pchar.ship.cargo.goods.balls);
+		break;
+	case GOOD_GRAPES:
+		BI_icons_ProjectilesUpdate = 35;
+		BattleInterface.textinfo.Ammo.text = "" + sti(pchar.ship.cargo.goods.grapes);
+		break;
+	case GOOD_KNIPPELS:
+		BI_icons_ProjectilesUpdate = 34;
+		BattleInterface.textinfo.Ammo.text = "" + sti(pchar.ship.cargo.goods.knippels);
+		break;
+	case GOOD_BOMBS:
+		BI_icons_ProjectilesUpdate = 33;
+		BattleInterface.textinfo.Ammo.text = "" + sti(pchar.ship.cargo.goods.bombs);
+		break;
+	}
+}
+
+void BI_UpdateCannons()
+{ // обновление состояния пушек в BattleInterface
+	int nShipType = sti(pchar.ship.type);
+	if (nShipType == SHIP_NOTUSED)
+	{
+		trace("ОШИБКА: ГГ без корабля");
+		return;
+	}
+
+	ref refBaseShip = GetRealShip(nShipType);
+
+	int fcannonsIntactCount = GetBortIntactCannonsNum(pchar, "fcannon", sti(refBaseShip.fcannon));
+	int bcannonsIntactCount = GetBortIntactCannonsNum(pchar, "bcannon", sti(refBaseShip.bcannon));
+	int lcannonsIntactCount = GetBortIntactCannonsNum(pchar, "lcannon", sti(refBaseShip.lcannon));
+	int rcannonsIntactCount = GetBortIntactCannonsNum(pchar, "rcannon", sti(refBaseShip.rcannon));
+
+	int allcannonsIntactCount = fcannonsIntactCount + bcannonsIntactCount + lcannonsIntactCount + rcannonsIntactCount;
+	BI_CannonsUpdate = (allcannonsIntactCount == 0);
+
+	BattleInterface.textinfo.CannonsNumF.text = fcannonsIntactCount + "/" + refBaseShip.fcannon;
+	BattleInterface.textinfo.CannonsNumB.text = bcannonsIntactCount + "/" + refBaseShip.bcannon;
+	BattleInterface.textinfo.CannonsNumL.text = lcannonsIntactCount + "/" + refBaseShip.lcannon;
+	BattleInterface.textinfo.CannonsNumR.text = rcannonsIntactCount + "/" + refBaseShip.rcannon;
+}

--- a/Program/nations/nations.c
+++ b/Program/nations/nations.c
@@ -227,7 +227,7 @@ int GetRelation(int iCharacterIndex1, int iCharacterIndex2)
 	return NationsRelations[iNation1 * MAX_NATIONS + iNation2];
 }
 
-int GetRelationEvent()
+int GetRelationEvent() // FPSTODO: в бою вызывается слишком часто, оптимизировать
 {
 	int iCharacterIndex1 = GetEventData();
 	int iCharacterIndex2 = GetEventData();


### PR DESCRIPTION
Убрал постоянный вызов procGetSRollSpeed для каждого корабля в сцене, который еще и вызывался каждый кадр.

Теперь апдейты скорости снятия/поднятия парусов будут происходить раз в секунду.