### PR TITLE
фикс - материалы за заказной корабль

### DIFF
--- a/Program/DIALOGS/russian/Common_Shipyard.c
+++ b/Program/DIALOGS/russian/Common_Shipyard.c
@@ -1500,7 +1500,7 @@ string checkOrderMatherial(ref NPChar)
 	string sLeft = "";
 	int idLngFile = LanguageOpenFile("ItemsDescribe.txt");
 
-	for (int k=0;k<8;k++)
+	for (int k=1;k<10;k++)
 	{
 		sGood1 = g_ShipBermudeTuningGoods[k];
 		amount = GetSquadronGoods(Pchar, FindGood(sGood1)) - sti(NPChar.questtemp.(sGood1));


### PR DESCRIPTION
неправильно проверялись последние два апгрейда(команда и калибр). наличие материалов не проверялось, и они не изымались у игрока.