### PR TITLE
фикс_неправильный учёт числа карт в атласе при квестовом аресте

### DIFF
--- a/Program/characters/LSC_Q2Utilite.c
+++ b/Program/characters/LSC_Q2Utilite.c
@@ -220,7 +220,7 @@ void SetHalfPerksToChar(ref _ch, bool _isOfficer)
 void RemoveAllCharacterItems(ref _ch, bool _removemoney)
 {
 	// сносим нафик всю экипировку
-	if(_ch == GetMainCharacter())
+	if(IsMainCharacter(_ch))
 	{
 		StoreEquippedMaps(_ch);
 		_ch.MapsAtlasCount = 0;


### PR DESCRIPTION
не удаляйте пока что ссылку на сообщение с сейвом по этому багу.  Я заметил, что в тюрьме доступны быстрые переходы!!!  Так что там ещё другой баг фиксить надо.