### PR TITLE
Исправление пряток

### DIFF
--- a/Program/DIALOGS/russian/Quest/ForAll_dialog.c
+++ b/Program/DIALOGS/russian/Quest/ForAll_dialog.c
@@ -2048,6 +2048,7 @@ void ProcessDialogEvent()
 			link.l1.go = "SCQ_Prytki_Dengi_Final";
 			
 			Event("QuestDelayExit","sl", "", 0);
+			PChar.quest.SCQ_Prytki_PokinuliZonu.over = "yes";
 			DeleteAttribute(pchar, "showTimer");
 			ClearAllLogStrings();
 			InterfaceStates.Buttons.Save.enable = true;

--- a/Program/Quests/quests_reaction.c
+++ b/Program/Quests/quests_reaction.c
@@ -11344,6 +11344,7 @@ void QuestComplete(string sQuestName, string qname)
 			sld.lifeday = 0;
 			ChangeCharacterAddressGroup(sld, "none", "", "");
 			InterfaceStates.Buttons.Save.enable = true;
+			PChar.quest.SCQ_Prytki_PokinuliZonu.over = "yes";
 		break;
 		
 		case "SCQ_Prytki_PokinuliZonu":


### PR DESCRIPTION
- При успешном выполнении задания, если мы сменим локацию, то больше не будет выводиться в лог, что мы "провалили задание".